### PR TITLE
Get dependencies from NuGet

### DIFF
--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/SCCMCliCtr.csproj
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/SCCMCliCtr.csproj
@@ -106,8 +106,12 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Windows.Controls.Input.Toolkit, Version=3.5.40128.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\System.Windows.Controls.Input.Toolkit.dll</HintPath>
+      <HintPath>..\packages\WPFToolkit.3.5.50211.1\lib\System.Windows.Controls.Input.Toolkit.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Windows.Controls.Layout.Toolkit, Version=3.5.40128.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WPFToolkit.3.5.50211.1\lib\System.Windows.Controls.Layout.Toolkit.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Windows.Controls.Ribbon" />
     <Reference Include="System.Xml" />
@@ -123,8 +127,9 @@
     <Reference Include="UIAutomationTypes" />
     <Reference Include="WindowsBase" />
     <Reference Include="WindowsFormsIntegration" />
-    <Reference Include="WPFToolkit">
-      <HintPath>..\WPFToolkit.dll</HintPath>
+    <Reference Include="WPFToolkit, Version=3.5.40128.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WPFToolkit.3.5.50211.1\lib\WPFToolkit.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -409,6 +414,7 @@
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/SCCMCliCtr.csproj
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/SCCMCliCtr.csproj
@@ -91,9 +91,8 @@
       <HintPath>..\NavigationPane.dll</HintPath>
     </Reference>
     <Reference Include="PresentationFramework.Aero" />
-    <Reference Include="sccmclictr.automation, Version=0.0.0.64, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\sccmclictrlib\sccmclictr.automation\bin\Debug\sccmclictr.automation.dll</HintPath>
+    <Reference Include="sccmclictr.automation">
+      <HintPath>..\packages\sccmclictrlib.0.0.0.41\lib\net40\sccmclictr.automation.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/SCCMCliCtr.csproj
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/SCCMCliCtr.csproj
@@ -91,8 +91,9 @@
       <HintPath>..\NavigationPane.dll</HintPath>
     </Reference>
     <Reference Include="PresentationFramework.Aero" />
-    <Reference Include="sccmclictr.automation">
-      <HintPath>..\packages\sccmclictrlib.0.0.0.41\lib\net40\sccmclictr.automation.dll</HintPath>
+    <Reference Include="sccmclictr.automation, Version=1.0.0.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\sccmclictrlib.1.0.0.6\lib\net40\sccmclictr.automation.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/packages.config
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="sccmclictrlib" version="0.0.0.41" targetFramework="net40" />
+  <package id="sccmclictrlib" version="1.0.0.6" targetFramework="net45" />
   <package id="WPFToolkit" version="3.5.50211.1" targetFramework="net45" />
 </packages>

--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/packages.config
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="sccmclictrlib" version="0.0.0.41" targetFramework="net40" />
+  <package id="WPFToolkit" version="3.5.50211.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
- Get WPFToolkit from NuGet to simplify building.
- Change sccmclictrlib's hintpath to point to the copy installed by NuGet.
- Update sccmclictrlib version installed to build successfully.