### PR TITLE
Add NavigationPane.dll to repo

### DIFF
--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/SCCMCliCtr.csproj
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/SCCMCliCtr.csproj
@@ -86,9 +86,9 @@
     <Reference Include="Fluent">
       <HintPath>..\Fluent.dll</HintPath>
     </Reference>
-    <Reference Include="NavigationPane, Version=1.0.4317.19063, Culture=neutral, PublicKeyToken=b239f36db07135c1, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\NavigationPane.dll</HintPath>
+    <Reference Include="NavigationPane, Version=1.0.5988.20744, Culture=neutral, PublicKeyToken=b239f36db07135c1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NavigationPane.2.1.0.0\lib\net40\NavigationPane.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="PresentationFramework.Aero" />
     <Reference Include="sccmclictr.automation, Version=1.0.0.6, Culture=neutral, processorArchitecture=MSIL">

--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/packages.config
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="NavigationPane" version="2.1.0.0" targetFramework="net45" />
   <package id="sccmclictrlib" version="1.0.0.6" targetFramework="net45" />
   <package id="WPFToolkit" version="3.5.50211.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
NavigationPane is hosted on CodePlex, appears to be abandoned, and is not available on nuget/similar. Its license allows us to distribute it, so add it to the repo to simplify building and reduce the risk of losing access to it.