### PR TITLE
Customization Placeholder

### DIFF
--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/Customization_Placeholder.cs
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/Customization_Placeholder.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace ClientCenter
+{
+    class SCCMCliCtr
+    {
+        public class Customization
+        {
+            public static String Title = "Placeholder Title";
+
+            public static bool CheckLicense() { return false; }
+
+            public static bool isOpenSource = true;
+        }
+    }
+}

--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/SCCMCliCtr.csproj
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/SCCMCliCtr.csproj
@@ -408,7 +408,7 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <Content Include="Customization.dll.config">
+    <Content Condition="Exists('Customization.dll.config')" Include="Customization.dll.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <SubType>Designer</SubType>
     </Content>

--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/SCCMCliCtr.csproj
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/SCCMCliCtr.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Controls\ImportApp.xaml.cs">
       <DependentUpon>ImportApp.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Customization_Placeholder.cs" />
     <Compile Include="ServiceWindowNew.xaml.cs">
       <DependentUpon>ServiceWindowNew.xaml</DependentUpon>
     </Compile>

--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/SCCMCliCtr.csproj
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/SCCMCliCtr.csproj
@@ -173,7 +173,7 @@
     <Compile Include="Controls\ImportApp.xaml.cs">
       <DependentUpon>ImportApp.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Customization_Placeholder.cs" />
+    <Compile Condition="!Exists('Customization.dll')" Include="Customization_Placeholder.cs" />
     <Compile Include="ServiceWindowNew.xaml.cs">
       <DependentUpon>ServiceWindowNew.xaml</DependentUpon>
     </Compile>
@@ -582,7 +582,7 @@
     <ManifestTimestampUrl>http://timestamp.verisign.com/scripts/timstamp.dll</ManifestTimestampUrl>
   </PropertyGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>


### PR DESCRIPTION
Members of `SCCMCliCtr.Customization` are required for SCCMCliCtr to build properly, but Customization.dll's not in git, so provide a placeholder. The placeholder is only included if Customization.dll is not present.

I'm not sure the Customization placeholder is providing the correct responses, but the software appears to be functioning as the open source version correctly.