### PR TITLE
Fix SCCM log parsing by ignoring UTC offset

### DIFF
--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/Controls/LogViewer.xaml.cs
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/Controls/LogViewer.xaml.cs
@@ -129,7 +129,10 @@ namespace ClientCenter.Controls
                                         string sComp = parts.First(p => p.StartsWith("component")).Split('=')[1].Replace("\"", "");
                                         string sDate = parts.First(p => p.StartsWith("date")).Split('=')[1].Replace("\"", ""); ;
                                         string sTime = parts.First(p => p.StartsWith("time")).Split('=')[1].Replace("\"", "").Split('-')[0];
-                                        DateTime logdate = DateTime.ParseExact(sDate + " " + sTime, "MM-dd-yyyy HH:mm:ss.fff", CultureInfo.InvariantCulture);
+
+                                        //Drop the UTC offset CM provides in minutes from the end of the time
+                                        DateTime logdate = DateTime.ParseExact(sDate + " " + sTime.Substring(0, 12), "MM-dd-yyyy HH:mm:ss.fff", CultureInfo.InvariantCulture);
+
                                         LastDT = logdate;
                                         LG.LogLines.Add(new LogGrid.LogEntry() { LogText = sText, Component = sComp, Date = logdate });
                                         continue;


### PR DESCRIPTION
The current format used for parsing times in the SCCM log format can't handle the UTC offsets SCCM uses, which are in minutes rather than hours.

CMTrace and CMLogViewer both just drop the offset from the times (time="08:06:34.590-60" date="09-02-2016" gets displayed as 02/09/2016 08:06:34), so do the same.

Fixes #45
