### PR TITLE
Show Software Updates EvaluationState as text

### DIFF
--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/Controls/SWUpdatesGrid.xaml
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/Controls/SWUpdatesGrid.xaml
@@ -47,7 +47,7 @@
             <DockPanel DockPanel.Dock="Top">
                 <DataGrid AutoGenerateColumns="False" HorizontalAlignment="Stretch" Name="dataGrid1" VerticalAlignment="Stretch" LoadingRow="dataGrid1_LoadingRow">
                     <DataGrid.Columns>
-                        <DataGridTextColumn Header="EvaluationState" Binding="{Binding Path=EvaluationState}"/>
+                        <DataGridTextColumn Header="EvaluationState" Binding="{Binding Path=EvaluationStateText}"/>
                         <DataGridTextColumn Header="Publisher" Binding="{Binding Path=Publisher}" SortDirection="Ascending"  />
                         <DataGridTextColumn Header="Name" Binding="{Binding Path=Name}" />
                         <DataGridTextColumn Header="ArticleID" Binding="{Binding Path=ArticleID}" SortDirection="Ascending"  />

--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/Controls/SWUpdatesGrid.xaml
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/Controls/SWUpdatesGrid.xaml
@@ -47,6 +47,7 @@
             <DockPanel DockPanel.Dock="Top">
                 <DataGrid AutoGenerateColumns="False" HorizontalAlignment="Stretch" Name="dataGrid1" VerticalAlignment="Stretch" LoadingRow="dataGrid1_LoadingRow">
                     <DataGrid.Columns>
+                        <DataGridTextColumn Header="EvaluationState" Binding="{Binding Path=EvaluationState}"/>
                         <DataGridTextColumn Header="Publisher" Binding="{Binding Path=Publisher}" SortDirection="Ascending"  />
                         <DataGridTextColumn Header="Name" Binding="{Binding Path=Name}" />
                         <DataGridTextColumn Header="ArticleID" Binding="{Binding Path=ArticleID}" SortDirection="Ascending"  />
@@ -54,52 +55,6 @@
                         <DataGridTextColumn Header="Deadline" Binding="{Binding Path=Deadline,  StringFormat='yyyy-MM-dd HH:mm:ss'}"/>
                         <DataGridTextColumn Header="Description" Binding="{Binding Path=Description}"/>
                         <DataGridTextColumn Header="PercentComplete" Binding="{Binding Path=PercentComplete}"/>
-                        <!--<DataGridTextColumn Header="EvaluationState" Binding="{Binding Path=EvaluationState}"/>-->
-                        <DataGridTemplateColumn Header="" IsReadOnly="True" CanUserReorder="False" CanUserResize="False" CanUserSort="False" DisplayIndex="0">
-                            <DataGridTemplateColumn.CellTemplate>
-                                <DataTemplate>
-                                    <Image Name="img" Source="/SCCMCliCtrWPF;component/Images/Invalid software update.gif" Height="16"></Image>
-                                    <DataTemplate.Triggers>
-                                        <DataTrigger Binding="{Binding EvaluationState}" Value="13">
-                                            <Setter TargetName="img" Property="Source" Value="/SCCMCliCtrWPF;component/Images/Warning.ico"/>
-                                        </DataTrigger>
-                                        <DataTrigger Binding="{Binding EvaluationState}" Value="21">
-                                            <Setter TargetName="img" Property="Source" Value="/SCCMCliCtrWPF;component/Images/Warning.ico"/>
-                                        </DataTrigger>
-                                        <DataTrigger Binding="{Binding EvaluationState}" Value="3">
-                                            <Setter TargetName="img" Property="Source" Value="/SCCMCliCtrWPF;component/Images/Icon140.ico"/>
-                                        </DataTrigger>
-                                        <DataTrigger Binding="{Binding EvaluationState}" Value="4">
-                                            <Setter TargetName="img" Property="Source" Value="/SCCMCliCtrWPF;component/Images/Send Receive.ico"/>
-                                        </DataTrigger>
-                                        <DataTrigger Binding="{Binding EvaluationState}" Value="5">
-                                            <Setter TargetName="img" Property="Source" Value="/SCCMCliCtrWPF;component/Images/Send Receive.ico"/>
-                                        </DataTrigger>
-                                        <DataTrigger Binding="{Binding EvaluationState}" Value="6">
-                                            <Setter TargetName="img" Property="Source" Value="/SCCMCliCtrWPF;component/Images/Icon140.ico"/>
-                                        </DataTrigger>
-                                        <DataTrigger Binding="{Binding EvaluationState}" Value="7">
-                                            <Setter TargetName="img" Property="Source" Value="/SCCMCliCtrWPF;component/Images/Icon140.ico"/>
-                                        </DataTrigger>
-                                        <DataTrigger Binding="{Binding EvaluationState}" Value="11">
-                                            <Setter TargetName="img" Property="Source" Value="/SCCMCliCtrWPF;component/Images/Icon140.ico"/>
-                                        </DataTrigger>
-                                        <DataTrigger Binding="{Binding EvaluationState}" Value="8">
-                                            <Setter TargetName="img" Property="Source" Value="/SCCMCliCtrWPF;component/Images/Flag.ico"/>
-                                        </DataTrigger>
-                                        <DataTrigger Binding="{Binding EvaluationState}" Value="9">
-                                            <Setter TargetName="img" Property="Source" Value="/SCCMCliCtrWPF;component/Images/Flag.ico"/>
-                                        </DataTrigger>
-                                        <DataTrigger Binding="{Binding EvaluationState}" Value="10">
-                                            <Setter TargetName="img" Property="Source" Value="/SCCMCliCtrWPF;component/Images/Flag.ico"/>
-                                        </DataTrigger>
-                                        <DataTrigger Binding="{Binding EvaluationState}" Value="16">
-                                            <Setter TargetName="img" Property="Source" Value="/SCCMCliCtrWPF;component/Images/Flag.ico"/>
-                                        </DataTrigger>
-                                    </DataTemplate.Triggers>
-                                </DataTemplate>
-                            </DataGridTemplateColumn.CellTemplate>
-                        </DataGridTemplateColumn>
                     </DataGrid.Columns>
                     <DataGrid.ContextMenu>
                         <ContextMenu>

--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/Controls/SWUpdatesGrid.xaml
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/Controls/SWUpdatesGrid.xaml
@@ -45,7 +45,7 @@
                 </ToolBar>
              </DockPanel>
             <DockPanel DockPanel.Dock="Top">
-                <DataGrid AutoGenerateColumns="False" HorizontalAlignment="Stretch" Name="dataGrid1" VerticalAlignment="Stretch" LoadingRow="dataGrid1_LoadingRow">
+                <DataGrid AutoGenerateColumns="False" HorizontalAlignment="Stretch" Name="dataGrid1" VerticalAlignment="Stretch" LoadingRow="dataGrid1_LoadingRow" ClipboardCopyMode="IncludeHeader">
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="EvaluationState" Binding="{Binding Path=EvaluationStateText}"/>
                         <DataGridTextColumn Header="Publisher" Binding="{Binding Path=Publisher}" SortDirection="Ascending"  />
@@ -55,6 +55,7 @@
                         <DataGridTextColumn Header="Deadline" Binding="{Binding Path=Deadline,  StringFormat='yyyy-MM-dd HH:mm:ss'}"/>
                         <DataGridTextColumn Header="Description" Binding="{Binding Path=Description}"/>
                         <DataGridTextColumn Header="PercentComplete" Binding="{Binding Path=PercentComplete}"/>
+                        <DataGridTextColumn Header="ErrorCode" Binding="{Binding Path=ErrorCode}"/>
                     </DataGrid.Columns>
                     <DataGrid.ContextMenu>
                         <ContextMenu>

--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/Controls/SWUpdatesGrid.xaml
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/Controls/SWUpdatesGrid.xaml
@@ -50,12 +50,12 @@
                         <DataGridTextColumn Header="EvaluationState" Binding="{Binding Path=EvaluationStateText}"/>
                         <DataGridTextColumn Header="Publisher" Binding="{Binding Path=Publisher}" SortDirection="Ascending"  />
                         <DataGridTextColumn Header="Name" Binding="{Binding Path=Name}" />
+                        <DataGridTextColumn Header="Deadline" Binding="{Binding Path=Deadline,  StringFormat='yyyy-MM-dd HH:mm:ss'}"/>
+                        <DataGridTextColumn Header="PercentComplete" Binding="{Binding Path=PercentComplete}"/>
+                        <DataGridTextColumn Header="ErrorCode" Binding="{Binding Path=ErrorCode, StringFormat={}0x{0:X8}}"/>
                         <DataGridTextColumn Header="ArticleID" Binding="{Binding Path=ArticleID}" SortDirection="Ascending"  />
                         <DataGridTextColumn Header="BulletinID" Binding="{Binding Path=BulletinID}" />
-                        <DataGridTextColumn Header="Deadline" Binding="{Binding Path=Deadline,  StringFormat='yyyy-MM-dd HH:mm:ss'}"/>
                         <DataGridTextColumn Header="Description" Binding="{Binding Path=Description}"/>
-                        <DataGridTextColumn Header="PercentComplete" Binding="{Binding Path=PercentComplete}"/>
-                        <DataGridTextColumn Header="ErrorCode" Binding="{Binding Path=ErrorCode}"/>
                     </DataGrid.Columns>
                     <DataGrid.ContextMenu>
                         <ContextMenu>


### PR DESCRIPTION
Also adds an error code column and remove the previous evaluation state icons, since EvaluationStateText is clearer.

Relies on EvaluationStateText being fixed in sccmclictrlib, which it is now/as of 1.0.0.27.