### PR TITLE
Set the owner of the "Unable to connect" warning

### DIFF
--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/MainPage.xaml.cs
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/MainPage.xaml.cs
@@ -596,7 +596,7 @@ namespace ClientCenter
                     ribAgentActions.IsEnabled = false;
                     ConnectionDock.Visibility = System.Windows.Visibility.Visible;
                     bt_Ping.Visibility = System.Windows.Visibility.Visible;
-                    MessageBox.Show(ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBox.Show(Application.Current.MainWindow,ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
                 }
 
                 Mouse.OverrideCursor = Cursors.Arrow;


### PR DESCRIPTION
Currently locks the main window as expected of a modal dialog correctly for failure of the first attempted connection (command line, target box, etc), but not for subsequent connections. This resolves that.