### PR TITLE
Connect console with PSCredential

### DIFF
--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/MainPage.xaml
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/MainPage.xaml
@@ -51,7 +51,7 @@
                                         </StackPanel>
                                         <StackPanel Orientation="Horizontal">
                                             <Label Content="Password:" Height="28" HorizontalAlignment="Left" VerticalAlignment="Top" Width="70" />
-                                            <PasswordBox Height="23" HorizontalAlignment="Left" Name="pb_Password" VerticalAlignment="Top" Width="140" KeyDown="pb_Password_KeyDown" />
+                                            <PasswordBox Height="23" HorizontalAlignment="Left" Name="pb_Password" VerticalAlignment="Top" Width="140"/>
                                         </StackPanel>
                                         <StackPanel Orientation="Horizontal">
                                             <Label Content="Port:" Height="28" HorizontalAlignment="Left" VerticalAlignment="Top" Width="80" />

--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/MainPage.xaml
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/MainPage.xaml
@@ -20,7 +20,7 @@
                     </LinearGradientBrush>
                 </DockPanel.Background>
                 <TextBlock Text="Target Computer: " VerticalAlignment="Center" Margin="15,0,0,0"></TextBlock>
-                <Controls:AutoCompleteBox Name="tb_TargetComputer2" Width="150" Height="25" Text="{Binding Source={x:Static p:Settings.Default}, Path=DefaultHostName, Mode=TwoWay}" KeyUp="tb_TargetComputer2_KeyUp" Populating="tb_TargetComputer2_Populating" TextChanged="tb_TargetComputer_TextChanged" />
+                <Controls:AutoCompleteBox Name="tb_TargetComputer2" Width="150" Height="25" Text="{Binding Source={x:Static p:Settings.Default}, Path=DefaultHostName, Mode=TwoWay}" Populating="tb_TargetComputer2_Populating" TextChanged="tb_TargetComputer_TextChanged" />
                 <Button Name="bt_Ping" Width="20" Height="20" Visibility="Hidden" Click="bt_Ping_Click" ToolTip="Ping the device...">
                     <StackPanel>
                         <Image Source="Images/Play.ico" />
@@ -68,7 +68,7 @@
 
                             <StackPanel Orientation="Horizontal" Height="30" VerticalAlignment="Center" Focusable="false">
                                 <TextBlock Text="Target Computer: " VerticalAlignment="Center"></TextBlock>
-                                <Controls:AutoCompleteBox Name="tb_TargetComputer" Text="127.0.0.1" Width="150" Height="25" Populating="tb_TargetComputer2_Populating" KeyUp="tb_TargetComputer_KeyUp" TextChanged="tb_TargetComputer2_TextChanged"/>
+                                <Controls:AutoCompleteBox Name="tb_TargetComputer" Width="150" Height="25" Populating="tb_TargetComputer2_Populating" TextChanged="tb_TargetComputer2_TextChanged"  Text="{Binding Source={x:Static p:Settings.Default}, Path=DefaultHostName, Mode=TwoWay}"/>
                                 <RibbonButton Name="bt_Connect" VerticalAlignment="Center" Label="Connect" Height="23" Click="bt_Connect_Click" />
                             </StackPanel>
                             <RibbonApplicationMenuItem Header="Console extensions..." StaysOpenOnClick="True" Focusable="false">

--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/MainPage.xaml.cs
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/MainPage.xaml.cs
@@ -1090,22 +1090,6 @@ namespace ClientCenter
             Common.Hostname = ((AutoCompleteBox)sender).Text;
         }
 
-        private void tb_TargetComputer2_KeyUp(object sender, KeyEventArgs e)
-        {
-            Mouse.OverrideCursor = Cursors.Wait;
-            if (e.Key == Key.Enter)
-            {
-                tb_TargetComputer2.Text = tb_TargetComputer2.Text.Trim();
-                tb_TargetComputer.Text = tb_TargetComputer2.Text;
-                bt_Connect_Click(sender, null);
-            }
-
-            Common.Hostname = ((AutoCompleteBox)sender).Text;
-
-            Mouse.OverrideCursor = Cursors.Arrow;
-
-        }
-
         private void tb_TargetComputer2_Populating(object sender, PopulatingEventArgs e)
         {
             try
@@ -1116,21 +1100,6 @@ namespace ClientCenter
                 oSender.PopulateComplete();
             }
             catch { }
-        }
-
-        private void tb_TargetComputer_KeyUp(object sender, KeyEventArgs e)
-        {
-            Mouse.OverrideCursor = Cursors.Wait;
-            if (e.Key == Key.Enter)
-            {
-                tb_TargetComputer.Text = tb_TargetComputer.Text.Trim();
-                tb_TargetComputer2.Text = tb_TargetComputer.Text;
-                bt_Connect_Click(sender, null);
-            }
-
-            Common.Hostname = ((AutoCompleteBox)sender).Text;
-
-            Mouse.OverrideCursor = Cursors.Arrow;
         }
 
         private void bt_Ping_Click(object sender, RoutedEventArgs e)

--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/MainPage.xaml.cs
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/MainPage.xaml.cs
@@ -797,31 +797,22 @@ namespace ClientCenter
             {
                 Process Explorer = new Process();
                 Explorer.StartInfo.FileName = "powershell.exe";
-                string sCred = "";
                 string sPS = string.Format(Properties.Settings.Default.OpenPSConsoleCommand, oAgent.TargetHostname, tb_wsmanport.Text);
+                if ((bool)cb_ssl.IsChecked) sPS += " -UseSSL";
+                Explorer.StartInfo.Arguments = @"-NoExit -Command " + sPS;
+
                 if (!string.IsNullOrEmpty(tb_Username.Text))
                 {
                     System.Management.Automation.PSCredential credential = new System.Management.Automation.PSCredential(tb_Username.Text, pb_Password.SecurePassword);
-                    sCred = System.Management.Automation.PSSerializer.Serialize(credential);
+                    string serializedCred = System.Management.Automation.PSSerializer.Serialize(credential);
                     string filename = System.IO.Path.GetTempFileName();
-                    File.WriteAllText(filename, sCred);
+                    File.WriteAllText(filename, serializedCred);
                     string creds = "(Import-Clixml " + filename + ")";
                     //creds += "; rm " + filename;
-
-
-                    if ((bool)cb_ssl.IsChecked)
-                        Explorer.StartInfo.Arguments = @"-NoExit -Command " + sPS + " -UseSSL -Credential " + creds;
-                    else
-                        Explorer.StartInfo.Arguments = @"-NoExit -Command " + sPS + " -Credential " + creds;
-
+                    
+                    Explorer.StartInfo.Arguments += " -Credential " + creds;
                 }
-                else
-                {
-                    if ((bool)cb_ssl.IsChecked)
-                        Explorer.StartInfo.Arguments = @"-NoExit -Command " + sPS + " -UseSSL";
-                    else
-                        Explorer.StartInfo.Arguments = @"-NoExit -Command " + sPS;
-                }
+
                 Explorer.StartInfo.WindowStyle = ProcessWindowStyle.Normal;
                 
                 Explorer.Start();

--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/MainPage.xaml.cs
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/MainPage.xaml.cs
@@ -27,7 +27,6 @@ namespace ClientCenter
     {
         public SCCMAgent oAgent;
         public MyTraceListener myTrace;
-        private bool bPasswordChanged = false;
         delegate void AnonymousDelegate();
 
         public MainPage()
@@ -471,15 +470,7 @@ namespace ClientCenter
                     PageReset();
 
                 }
-
-                if (bPasswordChanged)
-                {
-                    Properties.Settings.Default.Password = common.Encrypt(pb_Password.Password, Application.ResourceAssembly.ManifestModule.Name);
-                    Properties.Settings.Default.Save();
-                    //pb_Password.Password = Properties.Settings.Default.Password;
-                    bPasswordChanged = false;
-                }
-
+                
                 tb_TargetComputer.Text = tb_TargetComputer.Text.Trim();
                 tb_TargetComputer2.Text = tb_TargetComputer2.Text.Trim();
 
@@ -872,11 +863,6 @@ namespace ClientCenter
         private void tvSWDist_Loaded(object sender, RoutedEventArgs e)
         {
             tviSWDistOverview.IsSelected = true;
-        }
-
-        private void pb_Password_KeyDown(object sender, KeyEventArgs e)
-        {
-            bPasswordChanged = true;
         }
 
         private void btClientMachineAuthentication_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Store passwords provided as SecureStrings internally and provide them to PowerShell as a PSCredential when 'Open Console' is pressed. Fixes #64 

Password still has to be converted to a normal string to make the actual connection for WMI, as sccmclictrlib only accepts strings for `SCCMAgent()`'s constructors.