### PR TITLE
Removed the DCM section from the menu bar 

### DIFF
--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/MainPage.xaml
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/MainPage.xaml
@@ -111,9 +111,6 @@
                                 <RibbonButton Name="btPolicyAgentValidateUserPolicy" Label="Policy Agent Validate User Policy" ToolTip="Policy Agent Validate User Policy" SmallImageSource="/SCCMCliCtrWPF;component/Images/UserPolicy.ico" Click="btPolicyAgentValidateUserPolicy_Click"></RibbonButton>
                             </RibbonSplitButton>
                         </RibbonGroup>
-                        <RibbonGroup Header="DCM" ToolTip="Settings Management (DCM)" SmallImageSource="Images/Search File.ico">
-                            <RibbonButton Name="ButtonDCMEval" Label="DCM Check" ToolTip="Desired Configuration Monitoring (DCM) Evaluation cycle." LargeImageSource="/SCCMCliCtrWPF;component/Images/Search%20File.ico" SmallImageSource="/SCCMCliCtrWPF;component/Images/Search%20File.ico" Click="ButtonDCMEval_Click" />
-                        </RibbonGroup>
                         <RibbonGroup Header="Updates" ToolTip="Update management" SmallImageSource="Images/SWUpdate.png">
                             <RibbonSplitButton Name="ButtonEvaluateUpdates1" Label="Update Evaluation" ToolTip="Software Update Assignment and Evaluation cycle." LargeImageSource="Images/SWUpdate.png" SmallImageSource="Images/SWUpdate.png" Click="ButtonEvaluateUpdates_Click">
                                 <RibbonButton Name="ButtonScanUpdates" Label="Update Scan" ToolTip="Force a Software Update Scan cycle."  SmallImageSource="/SCCMCliCtrWPF;component/Images/SWUpdate.png" Click="ButtonScanUpdates_Click" />
@@ -141,7 +138,6 @@
                                 <RibbonButton Name="btExternaleventdetection" Label="External event detection" SmallImageSource="/SCCMCliCtrWPF;component/Images/Repair.ico" Click="btExternaleventdetection_Click" />
                                 <RibbonButton Name="btSWMeteringUsageRport" Label="Software Metering Generating Usage Report" SmallImageSource="/SCCMCliCtrWPF;component/Images/Repair.ico" Click="btSWMeteringUsageRport_Click" ToolTip="Generate SoftwareMetering usage report" />
                                 <RibbonButton Name="btMSISourceListUpdate" Label="Windows Installer Source List Update Cycle" SmallImageSource="/SCCMCliCtrWPF;component/Images/Repair.ico" Click="btMSISourceListUpdate_Click" ToolTip="Update MSI Source List" />
-                                <RibbonButton Name="btDCMPolicyAction" Label="DCM Policy Action" SmallImageSource="/SCCMCliCtrWPF;component/Images/Repair.ico" Click="btDCMPolicyAction_Click" />
                                 <RibbonButton Name="btATMStatusCheckPolicy" Label="AMT Status Check Policy" SmallImageSource="/SCCMCliCtrWPF;component/Images/Repair.ico" Click="btATMStatusCheckPolicy_Click" />
                                 <RibbonButton Name="btPowerManagerSummarizer" Label="Power management start summarizer" SmallImageSource="/SCCMCliCtrWPF;component/Images/Repair.ico" Click="btPowerManagerSummarizer_Click" />
                                 <RibbonButton Name="btResetPausedSWDist" Label="Reset Paused Software Distribution" SmallImageSource="/SCCMCliCtrWPF;component/Images/Repair.ico" Click="btResetPausedSWDist_Click" ToolTip="Reset the Pause SoftwareDistribution Flag" />

--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/MainPage.xaml.cs
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/MainPage.xaml.cs
@@ -758,13 +758,6 @@ namespace ClientCenter
             Mouse.OverrideCursor = Cursors.Arrow;
         }
 
-        private void ButtonDCMEval_Click(object sender, RoutedEventArgs e)
-        {
-            Mouse.OverrideCursor = Cursors.Wait;
-            oAgent.Client.AgentActions.DCMPolicy();
-            Mouse.OverrideCursor = Cursors.Arrow;
-        }
-
         private void btResetPolicy_Click(object sender, RoutedEventArgs e)
         {
             Mouse.OverrideCursor = Cursors.Wait;
@@ -1042,13 +1035,6 @@ namespace ClientCenter
         {
             Mouse.OverrideCursor = Cursors.Wait;
             oAgent.Client.AgentActions.MSISourceListUpdate();
-            Mouse.OverrideCursor = Cursors.Arrow;
-        }
-
-        private void btDCMPolicyAction_Click(object sender, RoutedEventArgs e)
-        {
-            Mouse.OverrideCursor = Cursors.Wait;
-            oAgent.Client.AgentActions.DCMPolicy();
             Mouse.OverrideCursor = Cursors.Arrow;
         }
 


### PR DESCRIPTION
Removed the DCM section from the menu bar and the DCM option from the drop down. The DCM functions have been moved to the machine policy refresh in the SCCM client.