### PR TITLE
Use real customization dll if present

### DIFF
--- a/Customization/Customization.csproj
+++ b/Customization/Customization.csproj
@@ -30,9 +30,19 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="*.cs" />
     <Compile Condition="Exists('Customization.cs')" Remove="Customization_Placeholder.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>cd $(ProjectDir)
+set realcustomization="..\..\..\Visual Studio 2010\Project_ClientCenter\SCCMCliCtr_WPF\Customization\bin\Release\Customization.dll"
+IF EXIST %25realcustomization%25 (
+xcopy /y %25realcustomization%25 $(TargetDir)
+)</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/SCCMCliCtr.csproj
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/SCCMCliCtr.csproj
@@ -78,10 +78,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Customization, Version=3.0.0.9, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Visual Studio 2010\Project_ClientCenter\SCCMCliCtr_WPF\Customization\bin\Release\Customization.dll</HintPath>
-    </Reference>
     <Reference Include="NavigationPane, Version=1.0.5988.20744, Culture=neutral, PublicKeyToken=b239f36db07135c1, processorArchitecture=MSIL">
       <HintPath>..\packages\NavigationPane.2.1.0.0\lib\net40\NavigationPane.dll</HintPath>
       <Private>True</Private>
@@ -546,6 +542,12 @@
   </ItemGroup>
   <ItemGroup>
     <WCFMetadata Include="Service References\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Customization\Customization.csproj">
+      <Project>{2956a544-f6d5-4799-899f-583ee5f2df58}</Project>
+      <Name>Customization</Name>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup>
   </PropertyGroup>


### PR DESCRIPTION
Add a post-build task to customization.csproj to check if Customization.dll is present at the path referenced in [1], and copy it to the project's output dir, meaning the "real" file will be used if present, but the placeholder resulting from the build will be used if not.

This should result in easy packaging for release with no change to workflow, but also mean the code in git can be immediately built, allowing for easier contributions and the availability of build artifacts and testing via CI.

[1]: https://github.com/rzander/sccmclictr/blob/550a8fb01bc889e83074575eed127bcd346b908d/SCCMCliCtrWPF/SCCMCliCtrWPF/SCCMCliCtr.csproj#L83