### PR TITLE
Explorer plugin

### DIFF
--- a/Plugins/Plugin_Explorer/CustomTools_Explorer.xaml
+++ b/Plugins/Plugin_Explorer/CustomTools_Explorer.xaml
@@ -7,8 +7,8 @@
              d:DesignHeight="300" d:DesignWidth="300">
     <Grid>
         <RibbonGroup Header="Explorer" Name="_rgExplorer">
-            <RibbonSplitButton Label="Explore Shares..." Name="btExplore" SmallImageSource="Images/shell32.dll_I010b_0409.ico" LargeImageSource="Images/shell32_4.ico" >
-                <RibbonButton Name="btC" Label="C$" ToolTip="C$ Share" SmallImageSource="Images/shell32.dll_I010b_0409.ico" Click="btC_Click" Tag="C" />
+            <RibbonSplitButton Label="Explore Shares..." Name="btExplore" SmallImageSource="Images/shell32.dll_I010b_0409.ico" LargeImageSource="Images/shell32_4.ico" Click="btC_Click" Tag="C" >
+                <RibbonButton Name="btC" Label="C$" ToolTip="C$ Share" SmallImageSource="Images/shell32.dll_I010b_0409.ico" Click="btC_Click" Tag="C" FontWeight="Bold" />
                 <RibbonButton Name="btAdmin" Label="Admin$" ToolTip="Admin$ Share" SmallImageSource="Images/shell32.dll_I010b_0409.ico" Click="btC_Click" Tag="Admin" />
                 <RibbonButton Name="btWBEM" Label="WBEM" ToolTip="Admin$\Wbem Share" SmallImageSource="Images/shell32.dll_I010b_0409.ico" Click="btC_Click" Tag="WBEM"/>
                 <RibbonButton Name="btCCM" Label="CCM Logs" ToolTip="CCM Agent Logs" SmallImageSource="Images/shell32.dll_I010b_0409.ico" Click="btC_Click" Tag="CCMLOGS" />

--- a/Plugins/Plugin_Explorer/CustomTools_Explorer.xaml.cs
+++ b/Plugins/Plugin_Explorer/CustomTools_Explorer.xaml.cs
@@ -40,9 +40,9 @@ namespace AgentActionTools
             try
             {
 
-                if (((RibbonButton)sender).Tag != null)
+                if (((FrameworkElement)sender).Tag != null)
                 {
-                    string sTag = ((RibbonButton)sender).Tag.ToString();
+                    string sTag = ((FrameworkElement)sender).Tag.ToString();
                     string sShare = "";
                     switch (sTag)
                     {

--- a/Plugins/Plugin_Explorer/Explorer.xaml
+++ b/Plugins/Plugin_Explorer/Explorer.xaml
@@ -6,8 +6,8 @@
              mc:Ignorable="d" 
              d:DesignHeight="100" d:DesignWidth="120">
     <Grid x:Name="gExplore" VerticalAlignment="Top" HorizontalAlignment="Left" ToolTip="Explore shares">
-        <RibbonSplitButton Label="Explore Shares..." Name="btExplore" SmallImageSource="Images/shell32.dll_I010b_0409.ico" >
-            <RibbonButton Name="btC" Label="C$" ToolTip="C$ Share" SmallImageSource="Images/shell32.dll_I010b_0409.ico" Click="btC_Click" Tag="C" />
+        <RibbonSplitButton Label="Explore Shares..." Name="btExplore" SmallImageSource="Images/shell32.dll_I010b_0409.ico" Click="btC_Click" Tag="C" >
+            <RibbonButton Name="btC" Label="C$" ToolTip="C$ Share" SmallImageSource="Images/shell32.dll_I010b_0409.ico" Click="btC_Click" Tag="C" FontWeight="Bold" />
             <RibbonButton Name="btAdmin" Label="Admin$" ToolTip="Admin$ Share" SmallImageSource="Images/shell32.dll_I010b_0409.ico" Click="btC_Click" Tag="Admin" />
             <RibbonButton Name="btWBEM" Label="WBEM" ToolTip="Admin$\Wbem Share" SmallImageSource="Images/shell32.dll_I010b_0409.ico" Click="btC_Click" Tag="WBEM"/>
             <RibbonButton Name="btCCM" Label="CCM Logs" ToolTip="CCM Agent Logs" SmallImageSource="Images/shell32.dll_I010b_0409.ico" Click="btC_Click" Tag="CCMLOGS" />

--- a/Plugins/Plugin_Explorer/Explorer.xaml
+++ b/Plugins/Plugin_Explorer/Explorer.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="AgentActionTools.AgentActionTool_FEPFullScan"
+﻿<UserControl x:Class="AgentActionTools.AgentActionTool_Explorer"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -13,6 +13,5 @@
             <RibbonButton Name="btCCM" Label="CCM Logs" ToolTip="CCM Agent Logs" SmallImageSource="Images/shell32.dll_I010b_0409.ico" Click="btC_Click" Tag="CCMLOGS" />
             <RibbonButton Name="btccmsetup" Label="ccmsetup Logs" ToolTip="Admin$\ccmsetup\logs Share" SmallImageSource="Images/shell32.dll_I010b_0409.ico" Click="btC_Click" Tag="ccmsetup"/>
         </RibbonSplitButton>
-        <!--<rib:RibbonButton Name="btFullScan" Label="Explore Shares..." ToolTip="Quick Scan" SmallImageSource="Images/shell32.dll_I010b_0409.ico" />-->
     </Grid>
 </UserControl>

--- a/Plugins/Plugin_Explorer/Explorer.xaml.cs
+++ b/Plugins/Plugin_Explorer/Explorer.xaml.cs
@@ -15,10 +15,10 @@ namespace AgentActionTools
     /// <summary>
     /// Interaction logic for UserControl1.xaml
     /// </summary>
-    public partial class AgentActionTool_FEPFullScan : System.Windows.Controls.UserControl
+    public partial class AgentActionTool_Explorer : System.Windows.Controls.UserControl
     {
         public SCCMAgent oAgent;
-        public AgentActionTool_FEPFullScan()
+        public AgentActionTool_Explorer()
         {
             InitializeComponent();
             btExplore.IsEnabled = SCCMCliCtr.Customization.CheckLicense();

--- a/Plugins/Plugin_Explorer/Explorer.xaml.cs
+++ b/Plugins/Plugin_Explorer/Explorer.xaml.cs
@@ -48,14 +48,14 @@ namespace AgentActionTools
         {
             try{
 
-                if (((RibbonButton)sender).Tag != null)
+                if (((FrameworkElement)sender).Tag != null)
                 {
                     Type t = System.Reflection.Assembly.GetEntryAssembly().GetType("ClientCenter.Common", false, true);
                     System.Reflection.PropertyInfo pInfo = t.GetProperty("Agent");
                     oAgent = (SCCMAgent)pInfo.GetValue(null, null);
                     string sHost = oAgent.TargetHostname;
 
-                    string sTag = ((RibbonButton)sender).Tag.ToString();
+                    string sTag = ((FrameworkElement)sender).Tag.ToString();
                     string sShare = "";
                     switch(sTag)
                     {

--- a/Plugins/Plugin_Explorer/Plugin_Explorer.csproj
+++ b/Plugins/Plugin_Explorer/Plugin_Explorer.csproj
@@ -47,8 +47,9 @@
     </AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="sccmclictr.automation, Version=1.0.0.18, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\sccmclictrlib.1.0.0.18\lib\net46\sccmclictr.automation.dll</HintPath>
+    <Reference Include="sccmclictr.automation, Version=1.0.0.34, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\SCCMCliCtrWPF\packages\sccmclictrlib.1.0.0.34\lib\net46\sccmclictr.automation.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -62,7 +63,6 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="WPFToolkit, Version=3.5.40128.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="CustomTools_Explorer.xaml">

--- a/Plugins/Plugin_Explorer/Plugin_Explorer.csproj
+++ b/Plugins/Plugin_Explorer/Plugin_Explorer.csproj
@@ -47,9 +47,6 @@
     </AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Customization">
-      <HintPath>..\Customization\bin\Debug\Customization.dll</HintPath>
-    </Reference>
     <Reference Include="sccmclictr.automation, Version=1.0.0.18, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\sccmclictrlib.1.0.0.18\lib\net46\sccmclictr.automation.dll</HintPath>
     </Reference>
@@ -107,6 +104,12 @@
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Customization\Customization.csproj">
+      <Project>{2956a544-f6d5-4799-899f-583ee5f2df58}</Project>
+      <Name>Customization</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Plugins/Plugin_Explorer/packages.config
+++ b/Plugins/Plugin_Explorer/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="sccmclictrlib" version="1.0.0.18" targetFramework="net46" />
+  <package id="sccmclictrlib" version="1.0.0.34" targetFramework="net46" />
 </packages>

--- a/SCCMCliCtrWPF/SCCMCliCtrWPF.sln
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SCCMCliCtrTests", "SCCMCliC
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Customization", "..\Customization\Customization.csproj", "{2956A544-F6D5-4799-899F-583EE5F2DF58}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Plugin_Explorer", "..\Plugins\Plugin_Explorer\Plugin_Explorer.csproj", "{32500CFB-9311-4590-AA83-FB5A1F4DBCF3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{2956A544-F6D5-4799-899F-583EE5F2DF58}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2956A544-F6D5-4799-899F-583EE5F2DF58}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2956A544-F6D5-4799-899F-583EE5F2DF58}.Release|Any CPU.Build.0 = Release|Any CPU
+		{32500CFB-9311-4590-AA83-FB5A1F4DBCF3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{32500CFB-9311-4590-AA83-FB5A1F4DBCF3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{32500CFB-9311-4590-AA83-FB5A1F4DBCF3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{32500CFB-9311-4590-AA83-FB5A1F4DBCF3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SCCMCliCtrWPF/SCCMCliCtrWPF/SCCMCliCtr.csproj
+++ b/SCCMCliCtrWPF/SCCMCliCtrWPF/SCCMCliCtr.csproj
@@ -548,6 +548,10 @@
       <Project>{2956a544-f6d5-4799-899f-583ee5f2df58}</Project>
       <Name>Customization</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\Plugins\Plugin_Explorer\Plugin_Explorer.csproj">
+      <Project>{32500cfb-9311-4590-aa83-fb5a1f4dbcf3}</Project>
+      <Name>Plugin_Explorer</Name>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup>
   </PropertyGroup>


### PR DESCRIPTION
Add Explorer plugin to main solution, make clicking the Explorer splitbutton open C: and make the custom tools Explorer work out the CCM Logs location correctly like the Agent Actions one.

Explorer plugin will now be included automatically when SCCMCliCtr is built.